### PR TITLE
handle fx accounts ver.json

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,13 @@ class ShasView(MethodView):
                 url += '?'
             url += 'cachescramble=%s' % time.time()
             content = urllib.urlopen(url).read().strip()
+            if content.startswith('{'):
+                # this might be json
+                try:
+                    data = json.loads(content)
+                    content = data['commit']
+                except:
+                    pass
             if not 7 <= len(content) <= 40:
                 # doesn't appear to be a git sha
                 error = (


### PR DESCRIPTION
add support for fx accounts style json version string - https://api-accounts.stage.mozaws.net . If it's invalid json or can't find commit key, the existing error should return