### PR TITLE
Include owner and repo in more places, to make pages easier to read

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -145,3 +145,7 @@ th > .column-extra {
   font-weight: normal;
   margin-right: 20px;
 }
+
+h2 .reponame {
+  color: #666;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Link } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 import Routes from './Routes';
@@ -10,21 +10,10 @@ export default class App extends React.Component {
     return (
       <Router>
         <div className="App container">
-          <Header />
           <Routes />
           <Footer />
         </div>
       </Router>
-    );
-  }
-}
-
-class Header extends React.Component {
-  render() {
-    return (
-      <h2 className="text-center">
-        <Link to="/">What's Deployed?</Link>
-      </h2>
     );
   }
 }

--- a/src/DeployPage.js
+++ b/src/DeployPage.js
@@ -51,10 +51,7 @@ class DeployPage extends React.Component {
   async decodeShortCode() {
     const {
       history,
-      location,
-      match: {
-        params,
-      }
+      match: { params }
     } = this.props;
     this.startLoad('parameters');
     try {
@@ -151,7 +148,19 @@ class DeployPage extends React.Component {
       <div>
         <h2 className="text-center">
           What's Deployed
-          {owner && repo && ` on ${owner}/${repo}`}?
+          {owner && repo && (
+            <span>
+              {' '}
+              on{' '}
+              <a
+                href={`https://github.com/${owner}/${repo}`}
+                className="reponame"
+              >
+                {owner}/{repo}
+              </a>
+            </span>
+          )}
+          ?
         </h2>
         {error && <div className="alert alert-danger">{error.toString()}</div>}
         {this.isLoading() ? (

--- a/src/DeployPage.js
+++ b/src/DeployPage.js
@@ -16,19 +16,16 @@ class DeployPage extends React.Component {
     shortCode: PropTypes.string.isRequired
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      owner: null,
-      repo: null,
-      deployments: null,
-      commits: null,
-      deployInfo: null,
-      error: null,
-      loading: null,
-      tags: null
-    };
-  }
+  state = {
+    owner: null,
+    repo: null,
+    deployments: null,
+    commits: null,
+    deployInfo: null,
+    error: null,
+    loading: null,
+    tags: null
+  };
 
   isLoading() {
     if (this.state.loading === null) {
@@ -53,14 +50,20 @@ class DeployPage extends React.Component {
 
   async decodeShortCode() {
     const {
+      history,
+      location,
       match: {
-        params: { code }
+        params,
       }
     } = this.props;
     this.startLoad('parameters');
     try {
-      let { owner, repo, deployments } = await shortUrls.decode(code);
+      let { owner, repo, deployments } = await shortUrls.decode(params.code);
       this.setState({ owner, repo, deployments });
+      if (params.owner !== owner || params.repo !== repo) {
+        history.replace(`/s/${params.code}/${owner}/${repo}`);
+      }
+
       this.fetchShas();
       this.fetchCommits();
       this.finishLoad('parameters');
@@ -160,14 +163,12 @@ class DeployPage extends React.Component {
               targetTime={5000}
             />
           </>
+        ) : !deployInfo ? (
+          <div className="alert alert-danger">
+            No Deployment info could be found
+          </div>
         ) : (
           <>
-            {!deployInfo && (
-              <div className="alert alert-danger">
-                No Deployment info could be found
-              </div>
-            )}
-
             <DeployTable
               deployInfo={deployInfo}
               commits={commits}

--- a/src/DeployPage.js
+++ b/src/DeployPage.js
@@ -144,46 +144,45 @@ class DeployPage extends React.Component {
 
     document.title = `What's Deployed on ${owner}/${repo}?`;
 
-    if (error) {
-      return <div className="alert alert-danger">{error.toString()}</div>;
-    }
-
-    if (this.isLoading()) {
-      return (
-        <div>
-          <span>Loading {Array.from(loading || '...').join(' and ')}</span>
-          <AutoProgressBar
-            count={loading ? loading.size : 0}
-            total={3}
-            targetTime={5000}
-          />
-        </div>
-      );
-    }
-
-    if (!deployInfo) {
-      return (
-        <div className="alert alert-danger">
-          No Deployment info could be found
-        </div>
-      );
-    }
-
     return (
       <div>
-        <DeployTable
-          deployInfo={deployInfo}
-          commits={commits}
-          tags={tags}
-          shortUrl={`/s/${code}`}
-        />
-        <RepoSummary
-          deployInfo={deployInfo}
-          tags={tags}
-          owner={owner}
-          repo={repo}
-        />
-        <Culprits deployInfo={deployInfo} owner={owner} repo={repo} />
+        <h2 className="text-center">
+          What's Deployed
+          {owner && repo && ` on ${owner}/${repo}`}?
+        </h2>
+        {error && <div className="alert alert-danger">{error.toString()}</div>}
+        {this.isLoading() ? (
+          <>
+            <span>Loading {Array.from(loading || '...').join(' and ')}</span>
+            <AutoProgressBar
+              count={loading ? loading.size : 0}
+              total={3}
+              targetTime={5000}
+            />
+          </>
+        ) : (
+          <>
+            {!deployInfo && (
+              <div className="alert alert-danger">
+                No Deployment info could be found
+              </div>
+            )}
+
+            <DeployTable
+              deployInfo={deployInfo}
+              commits={commits}
+              tags={tags}
+              shortUrl={`/s/${code}`}
+            />
+            <RepoSummary
+              deployInfo={deployInfo}
+              tags={tags}
+              owner={owner}
+              repo={repo}
+            />
+            <Culprits deployInfo={deployInfo} owner={owner} repo={repo} />
+          </>
+        )}
       </div>
     );
   }

--- a/src/LongUrlRedirect.js
+++ b/src/LongUrlRedirect.js
@@ -59,7 +59,7 @@ class LongUrlRedirect extends React.Component {
     const { owner, repo } = this.props;
     const { error } = this.state;
 
-    document.title = `What's deployed on ${owner}/${repo}?`;
+    document.title = `What's Deployed on ${owner}/${repo}?`;
 
     if (error) {
       return <div className="alert alert-danger">{error.toString()}</div>;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -18,6 +18,7 @@ const Routes = withRouter(({ location }) => {
   return (
     <Switch>
       <Redirect from="/s-:code(.*)" to="/s/:code" />
+      <Route path="/s/:code/:owner/:repo" component={DeployPage} />
       <Route path="/s/:code" component={DeployPage} />
       <Route path="/" exact component={SetupPage} />
     </Switch>

--- a/src/SetupPage.js
+++ b/src/SetupPage.js
@@ -8,6 +8,9 @@ export default class SetupPage extends React.Component {
   render() {
     return (
       <div>
+        <h2 className="text-center">
+          What's Deployed
+        </h2>
         <SetupFormWithRouter />
         <PreviousEnvironments />
         <WhatIsIt />
@@ -76,7 +79,7 @@ class SetupForm extends React.Component {
 
   render() {
     const { owner, repository, rows } = this.state;
-    document.title = "What's deployed?";
+    document.title = "What's Deployed?";
 
     return (
       <form>

--- a/src/SetupPage.js
+++ b/src/SetupPage.js
@@ -8,9 +8,7 @@ export default class SetupPage extends React.Component {
   render() {
     return (
       <div>
-        <h2 className="text-center">
-          What's Deployed
-        </h2>
+        <h2 className="text-center">What's Deployed</h2>
         <SetupFormWithRouter />
         <PreviousEnvironments />
         <WhatIsIt />
@@ -176,7 +174,7 @@ class PreviousEnvironments extends React.Component {
           <ul>
             {environments.map(env => (
               <li key={env.shortlink}>
-                <Link to={`/s/${env.shortlink}`}>
+                <Link to={`/s/${env.shortlink}/${env.owner}/${env.repo}`}>
                   {env.owner}/{env.repo}
                 </Link>
                 <span className="names">


### PR DESCRIPTION
I added the owner/repo back to the title (by rendering it on the page instead of globally), and also to the URL, so our awesome bars are nicer.