### PR TITLE
w.author is null

### DIFF
--- a/src/DeployPage.js
+++ b/src/DeployPage.js
@@ -224,7 +224,7 @@ class DeployTable extends React.Component {
 
     const usersByLogin = new Map();
     for (const commit of commits) {
-      if (usersByLogin.has(commit.author.login)) {
+      if (!commit.author || usersByLogin.has(commit.author.login)) {
         continue;
       }
       usersByLogin.set(commit.author.login, commit.author);


### PR DESCRIPTION
Fixes #72

@mythmon I rushed through this fix. It made it work. Adrian on the Pontoon team noticed it. 

To reproduce type this in:

```
whatsdeployed=# select * from shortlink where link='9xt';
 id | link |  owner  |  repo   |                                                                   revisions
----+------+---------+---------+------------------------------------------------------------------------------------------------------------------------------------------------
 24 | 9xt  | mozilla | pontoon | [["Stagee", "https://mozilla-pontoon-staging.herokuapp.com/static/revision.txt"], ["Prod", "https://pontoon.mozilla.org/static/revision.txt"]]
(1 row)
```