### PR TITLE
correct way to get the latest tag name

### DIFF
--- a/bin/download-latest-release.py
+++ b/bin/download-latest-release.py
@@ -33,7 +33,17 @@ def _download(url):
 def cli(tag_name=None, verbose=False, destination=None):
     destination = destination or "."
     if not tag_name:
-        tag_name = _check_output("git tag".split()).splitlines()[0]
+        tag_name = _check_output(
+            [
+                "git",
+                "for-each-ref",
+                "--sort=-taggerdate",
+                "--count=1",
+                "--format",
+                "%(tag)",
+                "refs/tags",
+            ]
+        )
     assert tag_name
 
     for release in _download(URL):


### PR DESCRIPTION
This is what I've been using on github.com/mozilla-services/tecken for a "years". 