### PR TITLE
commit.author can be null

### DIFF
--- a/src/DeployPage.js
+++ b/src/DeployPage.js
@@ -288,7 +288,11 @@ class DeployTable extends React.Component {
         }
       }
 
-      if (commit.author.login === BORS_LOGIN && commit.author.type === 'Bot') {
+      if (
+        commit.author &&
+        commit.author.login === BORS_LOGIN &&
+        commit.author.type === 'Bot'
+      ) {
         hasBors = true;
       } else if (borsMode) {
         continue;

--- a/src/DeployPage.js
+++ b/src/DeployPage.js
@@ -434,7 +434,10 @@ class CommitDetails extends React.Component {
   render() {
     let { commit, author, tag, html_url, borsMode, owner, repo } = this.props;
 
-    let involvedUsers = [author];
+    let involvedUsers = [];
+    if (author) {
+      involvedUsers.push(author);
+    }
 
     let title;
     if (borsMode && author.login === BORS_LOGIN && author.type === 'Bot') {
@@ -660,7 +663,7 @@ class Culprits extends React.PureComponent {
                   <span className="on-prefix">On</span> {group.name}
                 </h4>
                 {group.users.map(([role, user]) => (
-                  <div key={`${role}:${user}`} className="media">
+                  <div key={`${role}:${user.login}`} className="media">
                     <a href={user.html_url}>
                       <img
                         src={user.avatar_url}


### PR DESCRIPTION
Fixes #86

This PR fixes the bug but there's probably other things we can do to display the commits if they don't have an author. For now it works at least:
<img width="1173" alt="Screen Shot 2019-04-15 at 9 09 47 AM" src="https://user-images.githubusercontent.com/26739/56135318-740bb680-5f5e-11e9-9413-02442d9757e8.png">

PS. [Here's the commit without author](https://github.com/mdn/kumascript/commit/4d9043b9bb962db2003677f8b0c6c79463e36867)