### PR TITLE
Update wording around default branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 What's deployed from a GitHub repo on various server environments?
 
-This requires that you have 2 or more URLs that return a git sha that
-references which git sha has been deployed.
+This requires that you have a URL returning the git SHA of a commit
+currently deployed in the environment. If this commit is present in your
+default branch and the repository is public, you will get a shortlink showing
+the state of individual deployments in relation to your commit history.
 
 ## Screenshots
 
@@ -51,9 +53,9 @@ yarn start
 
 This will automatically open your browser to http://localhost:3000/
 
-To avoid hitting rate limits on GitHub's API you can go to
+To avoid hitting rate limits on GitHub's API, you should go to your
 [Personal access tokens](https://github.com/settings/tokens) and generate
-a token (without any scopes). How can you set:
+a token (without any scopes). Then add it to the command or set it e.g.:
 
 ```
 export GITHUB_AUTH_TOKEN=afefdf213840aeb8007310ab05fc33eda51a0652

--- a/src/DeployPage.js
+++ b/src/DeployPage.js
@@ -321,7 +321,7 @@ class DeployTable extends React.Component {
           <thead>
             <tr>
               <th>
-                <span className="column-title">Commits on master</span>
+                <span className="column-title">Commits on GitHub</span>
                 {hasBors && (
                   <span className="column-extra">
                     There are commits here by <code>{BORS_LOGIN}</code>.{' '}
@@ -733,8 +733,8 @@ class BadgesAndUrls extends React.Component {
     const fullUrl = `${protocol}//${host}${shortUrl}/${owner}/${repo}`;
     const envs = deployInfo
       .map((deploy) => deploy.name.toLowerCase())
-      .join(',');
-    const badgeUrl = `https://img.shields.io/badge/whatsdeployed-${envs}-green.svg`;
+      .join('/');
+    const badgeUrl = `https://img.shields.io/badge/whatsdeployed-${envs}-teal.svg`;
     const badgeAlt = `What's deployed on ${envs}?`;
     const markdown = `[![${badgeAlt}](${badgeUrl})](${fullUrl})`;
     const restructuredText = `.. |whatsdeployed| image:: ${badgeUrl}\n    :target: ${fullUrl}`;

--- a/src/SetupPage.js
+++ b/src/SetupPage.js
@@ -223,8 +223,8 @@ class WhatIsIt extends React.Component {
           {`$ curl https://dev.example.com/deployed-version\n{"commit": "d16cc25d58252a2b7e6bb394cbefa76b147d64d3", "other": "stuff"}`}
         </pre>
         <p>
-          Once you've typed in the GitHub organization, GitHub repository and at
-          least one of these URLs you can generated a table that shows what's
+          Once you've typed in the GitHub organization, GitHub repository, and
+          at least one of these URLs, you can generate a table that shows what's
           been deployed on the server(s) compared to what's available in the{' '}
           default branch.
         </p>

--- a/src/SetupPage.js
+++ b/src/SetupPage.js
@@ -200,16 +200,16 @@ class WhatIsIt extends React.Component {
         <p>
           <b>
             It's a web service for visualizing the difference between code
-            committed to <code>master</code> in your GitHub project compared to
-            which code has been deployed in your dev, stage and/or production
-            environment(s).
+            committed to the <b>default branch</b> of your GitHub project
+            compared to which code has been deployed in your dev, stage and/or
+            production environment(s).
           </b>
         </p>
         <h4>The Basics</h4>
         <p>
           For this to work you need to have your code in a{' '}
           <b>public GitHub repository</b> and the git SHA that is deployed on
-          your server(s) need to be publicly available.
+          your server(s) has to be publicly available.
         </p>
         <p>
           The git SHA needs to be the content of the URL or it can be JSON that
@@ -226,17 +226,17 @@ class WhatIsIt extends React.Component {
           Once you've typed in the GitHub organization, GitHub repository and at
           least one of these URLs you can generated a table that shows what's
           been deployed on the server(s) compared to what's available in the{' '}
-          <code>master</code> branch.
+          default branch.
         </p>
         <h4>Examples</h4>
         <ul>
           <li>
             <a
-              href="https://whatsdeployed.io/s/5HY"
+              href="https://whatsdeployed.io/s/osf"
               target="_blank"
               rel="noopener noreferrer"
             >
-              mozilla-services/tecken
+              mozilla/pontoon
             </a>
           </li>
           <li>
@@ -250,7 +250,7 @@ class WhatIsIt extends React.Component {
           </li>
           <li>
             <a
-              href="https://whatsdeployed.io/s/pdF"
+              href="https://whatsdeployed.io/s/BIY"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -263,12 +263,12 @@ class WhatIsIt extends React.Component {
           This instance is public and free for anybody to use. The{' '}
           <a href="https://github.com/peterbe/whatsdeployed">source code</a> is
           open and available under the{' '}
-          <a href="http://www.mozilla.org/MPL/2.0/">MPL 2.0</a> license.
+          <a href="https://www.mozilla.org/MPL/2.0/">MPL 2.0</a> license.
         </p>
         <p>
-          It's just a <a href="http://flask.pocoo.org/">Flask</a> app and you
-          can install and run your own instance if you want to use this for your
-          private repositories.
+          It's just a <a href="https://flask.palletsprojects.com/">Flask</a> app
+          and you can install and run your own instance if you want to use this
+          for your private repositories.
         </p>
       </div>
     );


### PR DESCRIPTION
Fixes #336

Instead of putting the effort to somehow query what's the default branch name, and use it around the UI instead of implying `main`, `master`, `development` or something else for everyone… this makes the wording more universal in various places of the app, either hinting at a default branch, or rewording the source of data to still make some sense.

This also fixes some grammar while at it, and:
\+ Updates examples shown on page to some working deployments.
\+ Tweaks readme that only a single deployment is enough.
\+ Fixes badge contrast to make its content more legible.