### PR TITLE
Update CI to Python 3.9-3.10 and Node 20-22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,57 +1,37 @@
-name: CI Django and Node
-
+name: CI
 on:
   pull_request:
-
+  push:
+    branches: [master]
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        include:
+          - node: 20
+            python: '3.9'
+          - node: 22
+            python: '3.10'
+    name: node:${{ matrix.node }} / python:${{ matrix.python }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
-
-      - name: Cache node_modules
-        uses: actions/cache@v3.3.2
-        id: cached-node_modules
+          node-version: ${{ matrix.node }}
+          cache: yarn
+      - name: yarn> Install node modules
+        run: yarn --frozen-lockfile
+      - uses: actions/setup-python@v5
         with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
-      - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
-        run: |
-          yarn --frozen-lockfile
-
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
-
-      - name: Cache pip
-        uses: actions/cache@v3.3.2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install Dependencies
-        run: |
-          pip install -U pip wheel --progress-bar off
-          pip install -r requirements.txt --progress-bar off
-
-      - name: Run lints
+          python-version: ${{ matrix.python }}
+          cache: pip
+      - name: pip> Install dependencies
+        run: pip install -r requirements.txt
+      - name: Lint app & client
         run: |
           black --check app.py
           flake8 app.py
           yarn prettier:check
-
       - name: Build client
-        run: |
-          yarn run build
+        run: yarn run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.9-slim
 
 WORKDIR /app/
 RUN groupadd --gid 10001 app && useradd -g app --uid 10001 --shell /usr/sbin/nologin app
@@ -8,33 +8,32 @@ RUN apt-get update && \
 
 # Install Node and Yarn
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo 'deb https://deb.nodesource.com/node_10.x stretch main' > /etc/apt/sources.list.d/nodesource.list && \
-    echo 'deb-src https://deb.nodesource.com/node_10.x stretch main' >> /etc/apt/sources.list.d/nodesource.list && \
+    echo 'deb https://deb.nodesource.com/node_20.x bookworm main' > /etc/apt/sources.list.d/nodesource.list && \
+    echo 'deb-src https://deb.nodesource.com/node_20.x bookworm main' >> /etc/apt/sources.list.d/nodesource.list && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y nodejs yarn
 
 COPY ./requirements.txt /app/requirements.txt
-COPY ./requirements-constraints.txt /app/requirements-constraints.txt
 COPY ./package.json /app/package.json
 COPY ./yarn.lock /app/yarn.lock
 
 RUN pip install -U 'pip>=8' && \
     pip install --no-cache-dir -r requirements.txt --progress-bar off && \
-    yarn install --non-interactive --prod
+    yarn install --non-interactive
 
 # Install the app
 COPY . /app/
-RUN yarn build --prod
+RUN yarn build
 
 # Set Python-related environment variables to reduce annoying-ness
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PORT 5000
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PORT=5000
 
 USER app
 
 EXPOSE $PORT
 
-CMD python app.py
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ references which git sha has been deployed.
 
 ## License
 
-[MPL 2.0](http://www.mozilla.org/MPL/2.0/)
+[MPL 2.0](https://www.mozilla.org/MPL/2.0/)
 
 ## Credits
 
@@ -33,7 +33,6 @@ To install dependencies:
 
 ```
 pip install -r requirements.txt
-pip install -r dev-requirements.txt
 yarn install
 ```
 


### PR DESCRIPTION
Leaves EOLed versions behind and ensures the dependencies resolve and the app builds in currently supported Python and Node environments without any change 1:1.

This drops custom caching and leaves that to whatever the setup actions provide for the packaging ecosystems natively today. (Caches ~65MB of yarn data and ~15MB of pip dependencies implicitly…)

Example action runs: [actions/runs/14676233143/job/41192819445](https://github.com/janbrasna/whatsdeployed/actions/runs/14676233143/job/41192819445)

\+ Updates also Dockerfile to match.

\+ Fixes outdated dev instructions in readme.